### PR TITLE
VEIOSS-375 - Allow Traders to Input Correction Amount

### DIFF
--- a/app/controllers/corrections/CorrectionCountryController.scala
+++ b/app/controllers/corrections/CorrectionCountryController.scala
@@ -17,9 +17,10 @@
 package controllers.corrections
 
 import controllers.actions._
-import forms.CorrectionCountryFormProvider
+import forms.corrections.CorrectionCountryFormProvider
 import models.Index
-import pages.{CorrectionCountryPage, Waypoints}
+import pages.Waypoints
+import pages.corrections.CorrectionCountryPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import queries.AllCorrectionCountriesQuery
@@ -78,8 +79,7 @@ class CorrectionCountryController @Inject()(
           for {
             updatedAnswers <-
               Future.fromTry(request.userAnswers.set(CorrectionCountryPage(period, index), value))
-            _ <-
-              cc.sessionRepository.set(updatedAnswers)
+            _ <- cc.sessionRepository.set(updatedAnswers)
           } yield Redirect(CorrectionCountryPage(period, index).navigate(waypoints, request.userAnswers, updatedAnswers).route)
       )
   }

--- a/app/controllers/corrections/UndeclaredCountryCorrectionController.scala
+++ b/app/controllers/corrections/UndeclaredCountryCorrectionController.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.corrections
+
+import controllers.actions._
+import forms.corrections.UndeclaredCountryCorrectionFormProvider
+import models.requests.DataRequest
+import models.{Country, Index, Period}
+import pages.Waypoints
+import pages.corrections.{CorrectionCountryPage, UndeclaredCountryCorrectionPage}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.corrections.UndeclaredCountryCorrectionView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class UndeclaredCountryCorrectionController @Inject()(
+                                                       cc: AuthenticatedControllerComponents,
+                                                       formProvider: UndeclaredCountryCorrectionFormProvider,
+                                                       view: UndeclaredCountryCorrectionView
+                                                     )(implicit ec: ExecutionContext)
+  extends FrontendBaseController with I18nSupport {
+
+  private val form = formProvider()
+  protected val controllerComponents: MessagesControllerComponents = cc
+
+  def onPageLoad(waypoints: Waypoints, countryIndex: Index): Action[AnyContent] =
+    cc.authAndRequireData().async {
+      // ToDo: Downstream not ready to check Correction Eligibility yet.
+      // ToDo: Enhance the auth when ready
+      implicit request => {
+
+        val period = request.userAnswers.period
+        //Todo: Change this to correction period when ready
+
+        withCountryCorrected(period, countryIndex) { country => {
+          val preparedForm = request
+            .userAnswers.get(UndeclaredCountryCorrectionPage(period, countryIndex)) match {
+            case None => form
+            case Some(value) => form.fill(value)
+          }
+          Future.successful(Ok(view(preparedForm, waypoints, period, country, countryIndex)))
+        }
+        }
+      }
+    }
+
+  def onSubmit(waypoints: Waypoints, countryIndex: Index): Action[AnyContent] =
+    cc.authAndRequireData().async {
+      // ToDo: Downstream not ready to check Correction Eligibility yet.
+      // ToDo: Enhance the auth when ready
+      implicit request =>
+        val period = request.userAnswers.period
+        //Todo: Change this to correction period when ready
+        
+        withCountryCorrected(period, countryIndex) { country =>
+          form.bindFromRequest().fold(
+            formWithErrors => Future.successful(BadRequest(view(formWithErrors, waypoints, period, country, countryIndex))),
+            value =>
+              for {
+                updatedAnswers <- Future.fromTry(
+                  request.userAnswers.set(UndeclaredCountryCorrectionPage(period, countryIndex), value))
+                _ <- cc.sessionRepository.set(updatedAnswers)
+              } yield Redirect(UndeclaredCountryCorrectionPage(period, countryIndex).navigate(waypoints, request.userAnswers, updatedAnswers).route)
+          )
+        }
+    }
+
+  private def withCountryCorrected(period: Period, index: Index)
+                                  (block: Country => Future[Result])
+                                  (implicit request: DataRequest[AnyContent]): Future[Result] =
+    request.userAnswers.get(CorrectionCountryPage(period, index))
+      .fold(
+        Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+      )(
+        block(_)
+      )
+}

--- a/app/controllers/corrections/VatAmountCorrectionCountryController.scala
+++ b/app/controllers/corrections/VatAmountCorrectionCountryController.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.corrections
+
+import controllers.actions._
+import forms.corrections.VatAmountCorrectionCountryFormProvider
+import logging.Logging
+import models.requests.DataRequest
+import models.{Country, Index, Period}
+import pages.corrections.{CorrectionCountryPage, UndeclaredCountryCorrectionPage, VatAmountCorrectionCountryPage}
+import pages.{JourneyRecoveryPage, Waypoints}
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.FutureSyntax.FutureOps
+import views.html.corrections.VatAmountCorrectionCountryView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class VatAmountCorrectionCountryController @Inject()(
+                                                      override val messagesApi: MessagesApi,
+                                                      cc: AuthenticatedControllerComponents,
+                                                      formProvider: VatAmountCorrectionCountryFormProvider,
+                                                      view: VatAmountCorrectionCountryView
+                                                    )(implicit ec: ExecutionContext)
+  extends FrontendBaseController with I18nSupport with Logging {
+
+  protected val controllerComponents: MessagesControllerComponents = cc
+
+  def onPageLoad(waypoints: Waypoints, countryIndex: Index): Action[AnyContent] =
+    cc.authAndRequireData().async {
+      // ToDo: Downstream not ready to check Correction Eligibility yet.
+      // ToDo: Enhance the auth when ready
+      implicit request =>
+
+        val period = request.userAnswers.period
+        //Todo: Change this to correction period when ready
+
+        withCountryCorrected(waypoints, period, countryIndex) {
+          country =>
+            val form: Form[BigDecimal] = formProvider(country.name)
+
+            val preparedForm = request.userAnswers.get(VatAmountCorrectionCountryPage(period, countryIndex)) match {
+              case None => form
+              case Some(value) => form.fill(value)
+            }
+            Future.successful((Ok(view(preparedForm, waypoints, period, countryIndex, country))))
+        }
+
+    }
+
+  def onSubmit(waypoints: Waypoints, countryIndex: Index): Action[AnyContent] =
+    cc.authAndRequireData().async {
+      // ToDo: Downstream not ready to check Correction Eligibility yet.
+      // ToDo: Enhance the auth when ready
+      implicit request => {
+        val period = request.userAnswers.period
+        //Todo: Change this to correction period when ready
+        withCountryCorrected(waypoints, period, countryIndex) {
+          country=>
+            val form: Form[BigDecimal] = formProvider(country.name)
+
+            form.bindFromRequest().fold(
+              formWithErrors =>
+                BadRequest(view(formWithErrors, waypoints, period, countryIndex, country)).toFuture,
+              value =>
+                for {
+                  updatedAnswers <- Future.fromTry(request.userAnswers.set(VatAmountCorrectionCountryPage(period, countryIndex), value))
+                  _ <- cc.sessionRepository.set(updatedAnswers)
+                } yield Redirect(VatAmountCorrectionCountryPage(period, countryIndex).navigate(waypoints, request.userAnswers, updatedAnswers).route)
+            )
+        }
+      }
+    }
+
+
+  private def withCountryCorrected(waypoints: Waypoints, period: Period, index: Index)
+                                  (block: Country => Future[Result])
+                                  (implicit request: DataRequest[AnyContent]): Future[Result] =
+      request.userAnswers.get(CorrectionCountryPage(period, index))
+        .fold({
+          Future.successful(
+            Redirect(
+              JourneyRecoveryPage.navigate(
+                waypoints,
+                request.userAnswers,
+                request.userAnswers
+              ).route))
+        }
+        )(country =>
+          request.userAnswers.get(UndeclaredCountryCorrectionPage(period, index)) match {
+              case Some(true) =>
+                block(country)
+              case _ =>
+                Future.successful(
+                  Redirect(
+                    UndeclaredCountryCorrectionPage(period, index).route(waypoints)
+                  )
+                )
+          })
+}

--- a/app/controllers/corrections/VatPayableForCountryController.scala
+++ b/app/controllers/corrections/VatPayableForCountryController.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.corrections
+
+import controllers.actions._
+import forms.corrections.VatPayableForCountryFormProvider
+import models.requests.DataRequest
+import models.{Country, Index, Period}
+import pages.Waypoints
+import pages.corrections.{CorrectionCountryPage, VatAmountCorrectionCountryPage, VatPayableForCountryPage}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.corrections.VatPayableForCountryView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class VatPayableForCountryController @Inject()(
+                                                cc: AuthenticatedControllerComponents,
+                                                formProvider: VatPayableForCountryFormProvider,
+                                                view: VatPayableForCountryView
+                                              )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  protected val controllerComponents: MessagesControllerComponents = cc
+
+  def onPageLoad(waypoints: Waypoints, countryIndex: Index): Action[AnyContent] = cc.authAndRequireData().async {
+    // ToDo: Downstream not ready to check Correction Eligibility yet.
+    // ToDo: Enhance the auth when ready
+    implicit request =>
+      withAmountPeriodAndCountryCorrected(countryIndex) { data => {
+        val (selectedCountry, correctionPeriod, correctionAmount) = data
+          val form = formProvider(selectedCountry, correctionAmount)
+          val preparedForm = request.userAnswers.get(VatPayableForCountryPage(correctionPeriod, countryIndex)) match {
+            case None => form
+            case Some(value) => form.fill(value)
+          }
+          Future.successful(Ok(view(preparedForm, waypoints, countryIndex, selectedCountry, correctionPeriod, correctionAmount)))
+        }
+      }
+  }
+
+  def onSubmit(waypoints: Waypoints, countryIndex: Index): Action[AnyContent] =
+    cc.authAndRequireData().async {
+      // ToDo: Downstream not ready to check Correction Eligibility yet.
+      // ToDo: Enhance the auth when ready
+      implicit request =>
+        withAmountPeriodAndCountryCorrected(countryIndex) { data => {
+          val (selectedCountry, correctionPeriod, correctionAmount) = data
+            val form = formProvider(selectedCountry, correctionAmount)
+            form.bindFromRequest().fold(
+              formWithErrors =>
+                Future.successful(BadRequest(view(formWithErrors, waypoints, countryIndex, selectedCountry, correctionPeriod, correctionAmount))),
+              value =>
+                for {
+                  updatedAnswers <- Future.fromTry(request.userAnswers.set(VatPayableForCountryPage(correctionPeriod, countryIndex), value))
+                } yield Redirect(VatPayableForCountryPage(correctionPeriod, countryIndex).navigate(waypoints, request.userAnswers, updatedAnswers).route)
+            )
+          }
+        }
+    }
+
+  private def withAmountPeriodAndCountryCorrected(countryIndex: Index)
+                                                 (block: ((Country, Period, BigDecimal)) => Future[Result])
+                                                 (
+                                                   implicit request: DataRequest[AnyContent]
+                                                 ): Future[Result] = {
+    val correctionPeriod = request.userAnswers.period
+    //Todo: Change this to correction period when ready
+    val result: Option[(Country, Period, BigDecimal)] = for {
+      selectedCountry <- request.userAnswers.get(CorrectionCountryPage(correctionPeriod, countryIndex))
+      correctionAmount <- request.userAnswers.get(VatAmountCorrectionCountryPage(correctionPeriod, countryIndex))
+    } yield (selectedCountry, correctionPeriod, correctionAmount)
+
+    result
+      .fold(
+        Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+      )(block(_))
+  }
+}

--- a/app/forms/corrections/CorrectionCountryFormProvider.scala
+++ b/app/forms/corrections/CorrectionCountryFormProvider.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.corrections
+
+import forms.mappings.Mappings
+import models.Country.euCountriesWithNI
+import models.{Country, Index}
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class CorrectionCountryFormProvider @Inject() extends Mappings {
+
+  def apply(index: Index, existingAnswers: Seq[Country]): Form[Country] = {
+    val countries = euCountriesWithNI
+
+    Form(
+      "value" -> text("correctionCountry.error.required")
+        .verifying("correctionCountry.error.required", value => countries.exists(_.code == value))
+        .transform[Country](value => Country.euCountries.find(_.code == value).get, _.code)
+        .verifying(notADuplicate(index, existingAnswers, "correctionCountry.error.duplicate"))
+    )
+  }
+}

--- a/app/forms/corrections/UndeclaredCountryCorrectionFormProvider.scala
+++ b/app/forms/corrections/UndeclaredCountryCorrectionFormProvider.scala
@@ -14,25 +14,17 @@
  * limitations under the License.
  */
 
-package forms
+package forms.corrections
 
 import forms.mappings.Mappings
-import models.Country.euCountriesWithNI
-import models.{Country, Index}
 import play.api.data.Form
 
 import javax.inject.Inject
 
-class CorrectionCountryFormProvider @Inject() extends Mappings {
+class UndeclaredCountryCorrectionFormProvider @Inject() extends Mappings {
 
-  def apply(index: Index, existingAnswers: Seq[Country]): Form[Country] = {
-    val countries = euCountriesWithNI
-
+  def apply(): Form[Boolean] =
     Form(
-      "value" -> text("correctionCountry.error.required")
-        .verifying("correctionCountry.error.required", value => countries.exists(_.code == value))
-        .transform[Country](value => Country.euCountries.find(_.code == value).get, _.code)
-        .verifying(notADuplicate(index, existingAnswers, "correctionCountry.error.duplicate"))
+      "value" -> boolean("undeclaredCountryCorrection.error.required")
     )
-  }
 }

--- a/app/forms/corrections/VatAmountCorrectionCountryFormProvider.scala
+++ b/app/forms/corrections/VatAmountCorrectionCountryFormProvider.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.corrections
+
+import config.Constants.minCurrencyAmount
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class VatAmountCorrectionCountryFormProvider @Inject() extends Mappings {
+  def apply(country: String): Form[BigDecimal] =
+    Form(
+      "value" -> currency(
+        "vatAmountCorrectionCountry.error.required",
+        "vatAmountCorrectionCountry.error.wholeNumber",
+        "vatAmountCorrectionCountry.error.nonNumeric",
+        args = Seq(country))
+        .verifying(inRange[BigDecimal](
+          minCurrencyAmount, maxCurrencyAmount,
+         "vatAmountCorrectionCountry.error.outOfRange.undeclared"))
+        .verifying(nonZero("vatAmountCorrectionCountry.error.nonZero")))
+}

--- a/app/forms/corrections/VatPayableForCountryFormProvider.scala
+++ b/app/forms/corrections/VatPayableForCountryFormProvider.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.corrections
+
+import forms.mappings.Mappings
+import models.Country
+import play.api.data.Form
+import utils.CurrencyFormatter.currencyFormat
+
+import javax.inject.Inject
+
+class VatPayableForCountryFormProvider @Inject() extends Mappings {
+
+  def apply(country: Country, amount: BigDecimal): Form[Boolean] =
+    Form(
+      "value" -> boolean("vatPayableForCountry.error.required", args = Seq(country.name, currencyFormat(amount)))
+    )
+}

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -20,6 +20,7 @@ import models.{Index, VatRateFromCountry}
 
 import java.time.LocalDate
 import play.api.data.validation.{Constraint, Invalid, Valid}
+import utils.CurrencyFormatter
 
 trait Constraints {
 
@@ -31,6 +32,24 @@ trait Constraints {
           .map(_.apply(input))
           .find(_ != Valid)
           .getOrElse(Valid)
+    }
+
+  protected def minimumValueWithCurrency(minimum: BigDecimal, errorKey: String): Constraint[BigDecimal] =
+    Constraint {
+      input =>
+        if (input >= minimum) {
+          Valid
+        } else {
+          Invalid(errorKey, CurrencyFormatter.currencyFormat(minimum))
+        }
+    }
+
+  protected def nonZero(errorKey: String): Constraint[BigDecimal] =
+    Constraint {
+      case value if value == BigDecimal(0) =>
+        Invalid(errorKey)
+      case _ =>
+        Valid
     }
 
   protected def minimumValue[A](minimum: A, errorKey: String)(implicit ev: Ordering[A]): Constraint[A] =

--- a/app/pages/corrections/CorrectionCountryPage.scala
+++ b/app/pages/corrections/CorrectionCountryPage.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.corrections
+
+import models.{Country, Index, Period, UserAnswers}
+import pages.PageConstants.{corrections, correctionsToCountry}
+import pages.{Page, QuestionPage, Waypoints}
+import play.api.libs.json.JsPath
+import play.api.mvc.Call
+
+final case class CorrectionCountryPage(period: Period, index: Index) extends QuestionPage[Country] {
+
+  override def path: JsPath =
+    JsPath \ corrections \ period.toString \ correctionsToCountry \ index.position \ toString
+
+  override def toString: String = "correctionCountry"
+
+  override def route(waypoints: Waypoints): Call =
+    controllers.corrections.routes.CorrectionCountryController.onPageLoad(waypoints, index)
+
+  override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
+    UndeclaredCountryCorrectionPage(period, index)
+}

--- a/app/pages/corrections/UndeclaredCountryCorrectionPage.scala
+++ b/app/pages/corrections/UndeclaredCountryCorrectionPage.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.corrections
+
+import models.{Index, Period, UserAnswers}
+import pages.PageConstants.{corrections, correctionsToCountry}
+import pages.{JourneyRecoveryPage, Page, QuestionPage, Waypoints}
+import play.api.libs.json.JsPath
+import play.api.mvc.Call
+
+case class UndeclaredCountryCorrectionPage(period: Period, countryIndex: Index) extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ corrections \ period.toString \ correctionsToCountry \ countryIndex.position \ toString
+
+  override def toString: String = "undeclaredCountryCorrection"
+
+  override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
+    answers.get(UndeclaredCountryCorrectionPage(period, countryIndex)) match {
+      case Some(true) => VatAmountCorrectionCountryPage(period, countryIndex)
+      case Some(false) => CorrectionCountryPage(period, countryIndex)
+      case _ => JourneyRecoveryPage
+    }
+
+  override def route(waypoints: Waypoints): Call = controllers.corrections.routes.UndeclaredCountryCorrectionController.onPageLoad(waypoints, countryIndex)
+}

--- a/app/pages/corrections/VatAmountCorrectionCountryPage.scala
+++ b/app/pages/corrections/VatAmountCorrectionCountryPage.scala
@@ -14,23 +14,26 @@
  * limitations under the License.
  */
 
-package pages
+package pages.corrections
 
-import models.{Country, Index, Period, UserAnswers}
+import models.{Index, Period, UserAnswers}
 import pages.PageConstants.{corrections, correctionsToCountry}
+import pages.{JourneyRecoveryPage, Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
-final case class CorrectionCountryPage(period: Period, index: Index) extends QuestionPage[Country] {
+final case class VatAmountCorrectionCountryPage(period: Period, countryIndex: Index) extends QuestionPage[BigDecimal] {
 
-  override def path: JsPath =
-    JsPath \ corrections \ period.toString \ correctionsToCountry \ index.position \ toString
+  override def path: JsPath = JsPath \ corrections \ period.toString \ correctionsToCountry \ countryIndex.position \ toString
 
-  override def toString: String = "correctionCountry"
-
-  override def route(waypoints: Waypoints): Call =
-    controllers.corrections.routes.CorrectionCountryController.onPageLoad(waypoints, index) // Todo, will change when the next page is implemented
+  override def toString: String = "countryVatCorrection"
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
-    CorrectionCountryPage(period, index) // Todo, will change when the next page is implemented
+    answers.get(VatAmountCorrectionCountryPage(period, countryIndex)) match {
+      case Some(_) =>
+        VatPayableForCountryPage(period, countryIndex)
+      case _ => JourneyRecoveryPage
+    }
+
+  override def route(waypoints: Waypoints): Call = controllers.corrections.routes.VatAmountCorrectionCountryController.onPageLoad(waypoints, countryIndex)
 }

--- a/app/pages/corrections/VatPayableForCountryPage.scala
+++ b/app/pages/corrections/VatPayableForCountryPage.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.corrections
+
+import models.{Index, Period, UserAnswers}
+import pages.{JourneyRecoveryPage, Page, QuestionPage, Waypoints}
+import play.api.libs.json.JsPath
+import play.api.mvc.Call
+
+case class VatPayableForCountryPage(period: Period, countryIndex: Index) extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "vatPayableForCountry"
+
+  override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
+    answers.get(VatPayableForCountryPage(period, countryIndex)) match {
+      case Some(true) => JourneyRecoveryPage //Todo: This should be the next page. not mentioned.
+      case Some(false) => VatAmountCorrectionCountryPage(period, countryIndex)
+
+      case _ => JourneyRecoveryPage
+    }
+
+  override def route(waypoints: Waypoints): Call = controllers.corrections.routes.VatPayableForCountryController.onPageLoad(waypoints, countryIndex)
+}

--- a/app/views/corrections/UndeclaredCountryCorrectionView.scala.html
+++ b/app/views/corrections/UndeclaredCountryCorrectionView.scala.html
@@ -1,0 +1,61 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.hmrcfrontend.views.config.HmrcPageHeadingLegend
+@import components.ButtonGroup
+@import viewmodels.LegendSize
+@import pages.corrections.UndeclaredCountryCorrectionPage
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    button: ButtonGroup
+)
+
+@(form: Form[_], waypoints: Waypoints, correctionPeriod: Period, country: Country, countryIndex: Index)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("undeclaredCountryCorrection.title"))) {
+
+    @formHelper(action = controllers.corrections.routes.UndeclaredCountryCorrectionController.onSubmit(waypoints, countryIndex), 'autoComplete -> "off") {
+
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        <header class="hmrc-page-heading">
+            <p class="govuk-caption-xl hmrc-caption-xl">@messages("undeclaredCountryCorrection.caption", correctionPeriod.displayText)</p>
+            <h1 class="govuk-heading-xl">@messages("undeclaredCountryCorrection.heading", country.name)</h1>
+        </header>
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(
+                    HtmlContent(
+                        Html(messages("undeclaredCountryCorrection.legend"))
+                    )
+                ).withSize(LegendSize.Medium)
+            )
+        )
+
+        @button(
+            messages("site.continue", UndeclaredCountryCorrectionPage(correctionPeriod, countryIndex).route(waypoints).url, waypoints)
+        )
+    }
+}

--- a/app/views/corrections/VatAmountCorrectionCountryView.scala.html
+++ b/app/views/corrections/VatAmountCorrectionCountryView.scala.html
@@ -1,0 +1,62 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.hmrcfrontend.views.config.HmrcPageHeadingLabel
+@import viewmodels.InputWidth._
+@import components.ButtonGroup
+@import pages.corrections.VatAmountCorrectionCountryPage
+@import utils.CurrencyFormatter.currencyFormat
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    button: ButtonGroup
+)
+
+@(form: Form[_], waypoints: Waypoints, period: Period, countryIndex: Index, country: Country)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(
+    form,
+    messages("vatAmountCorrectionCountry.title",  country.name),
+    Some(messages("caption.fromCountry.periodAndCountry", period.displayText, country.name))
+)) {
+
+    @formHelper(action = controllers.corrections.routes.VatAmountCorrectionCountryController.onSubmit(waypoints, countryIndex), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = HmrcPageHeadingLabel(
+                    content = messages("vatAmountCorrectionCountry.heading", country.name),
+                    caption = messages("vatAmountCorrectionCountry.caption", period.displayText)
+                )
+            )
+            .withWidth(Fixed10)
+            .withCssClass("govuk-currency-input__inner__input")
+            .withPrefix(PrefixOrSuffix(content = Text("£")))
+        )
+
+        @button(
+            messages("site.continue", VatAmountCorrectionCountryPage(period, countryIndex).route(waypoints).url, waypoints)
+        )
+    }
+}

--- a/app/views/corrections/VatPayableForCountryView.scala.html
+++ b/app/views/corrections/VatPayableForCountryView.scala.html
@@ -1,0 +1,50 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import utils.CurrencyFormatter.currencyFormat
+@import components.ButtonGroup
+@import pages.corrections.VatPayableForCountryPage
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    button: ButtonGroup,
+)
+
+@(form: Form[_], waypoints: Waypoints, countryIndex: Index, selectedCountry: Country, correctionPeriod: Period, newAmount: BigDecimal)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("vatPayableForCountry.title", selectedCountry.name, currencyFormat(newAmount)))) {
+
+    @formHelper(action = controllers.corrections.routes.VatPayableForCountryController.onSubmit(waypoints, countryIndex), 'autoComplete -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = HmrcPageHeadingLegend(content = HtmlContent(Html(messages("vatPayableForCountry.heading", selectedCountry.name, currencyFormat(newAmount)))),
+                                caption = messages("vatPayableForCountry.caption", correctionPeriod.displayText))
+
+            ).withHint(HintViewModel(HtmlContent(Html(messages("vatPayableForCountry.hint")))))
+        )
+
+        @button(messages("site.continue",  VatPayableForCountryPage(correctionPeriod, countryIndex).route(waypoints).url, waypoints))
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -65,4 +65,11 @@ POST        /correct-previous-return                                            
 GET         /correction-country/:countryIndex                                         controllers.corrections.CorrectionCountryController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints, countryIndex: Index)
 POST        /correction-country/:countryIndex                                         controllers.corrections.CorrectionCountryController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints, countryIndex: Index)
 
+GET         /country-vat-correction-amount/:countryIndex                                controllers.corrections.VatAmountCorrectionCountryController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints, countryIndex: Index)
+POST        /country-vat-correction-amount/:countryIndex                                controllers.corrections.VatAmountCorrectionCountryController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints, countryIndex: Index)
 
+GET         /add-new-country/:countryIndex                                              controllers.corrections.UndeclaredCountryCorrectionController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints, countryIndex: Index)
+POST        /add-new-country/:countryIndex                                              controllers.corrections.UndeclaredCountryCorrectionController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints, countryIndex: Index)
+
+GET         /vat-payable-confirm/:countryIndex                                           controllers.corrections.VatPayableForCountryController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints, countryIndex: Index)
+POST        /vat-payable-confirm/:countryIndex                                           controllers.corrections.VatPayableForCountryController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints, countryIndex: Index)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -176,3 +176,30 @@ correctionCountry.change.hidden = which country you sold to
 correctionCountry.hint = You can also add a new country that was not included in your previous return.
 correctionCountry.error.required = Select which country you would like to correct
 correctionCountry.error.duplicate = You selected this country already. Select a different one.
+
+vatPayableForCountry.title = Is the total VAT payable for {0} {1}?
+vatPayableForCountry.heading = Is the total VAT payable for {0} {1}?
+vatPayableForCountry.caption = Correction period: {0}
+vatPayableForCountry.hint = We''ve calculated this total based on your most recent declaration and the correction amount.
+vatPayableForCountry.error.required = Select yes if the total VAT payable for {0} is {1}
+
+vatAmountCorrectionCountry.title = What is your correction for the VAT payable to {0}?
+vatAmountCorrectionCountry.heading = What is your correction for the VAT payable to {0}?
+vatAmountCorrectionCountry.caption = Correction period: {0}
+vatAmountCorrectionCountry.hint = Enter a minus value if you declared too much in your previous return.
+vatAmountCorrectionCountry.previous-amount.hint = Your most recent declaration for this period is {0}.
+vatAmountCorrectionCountry.checkYourAnswersLabel = Correction amount
+vatAmountCorrectionCountry.error.negative = The correction value cannot be less than {0}
+vatAmountCorrectionCountry.error.nonNumeric = Enter your correction for the total VAT payable to {0} using numbers
+vatAmountCorrectionCountry.error.required = Enter your correction for the total VAT payable to {0}
+vatAmountCorrectionCountry.error.wholeNumber = Enter your correction for the total VAT payable to {0} using whole numbers
+vatAmountCorrectionCountry.error.outOfRange = Correction for the total VAT payable must be between {0} and {1}
+vatAmountCorrectionCountry.error.outOfRange.undeclared = Correction for the total VAT payable must be less than {1}
+vatAmountCorrectionCountry.error.nonZero = Correction for the total VAT payable must not be zero
+vatAmountCorrectionCountry.change.hidden = Correction amount
+
+undeclaredCountryCorrection.title = You did not declare any VAT to {0} in your original return
+undeclaredCountryCorrection.heading = You did not declare any VAT to {0} in your original return
+undeclaredCountryCorrection.caption = Correction period: {0}
+undeclaredCountryCorrection.legend = Do you want to add a correction to this country?
+undeclaredCountryCorrection.error.required = Select yes if you want to add a correction to this country

--- a/test/controllers/corrections/CorrectionCountryControllerSpec.scala
+++ b/test/controllers/corrections/CorrectionCountryControllerSpec.scala
@@ -17,17 +17,18 @@
 package controllers.corrections
 
 import base.SpecBase
-import forms.CorrectionCountryFormProvider
+import forms.corrections.CorrectionCountryFormProvider
 import models.Country
 import org.mockito.Mockito.when
 import org.scalacheck.Arbitrary
 import org.scalatestplus.mockito.MockitoSugar
-import pages.CorrectionCountryPage
+import pages.corrections.CorrectionCountryPage
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.SessionRepository
 import views.html.corrections.CorrectionCountryView
+
 import scala.concurrent.Future
 
 class CorrectionCountryControllerSpec extends SpecBase with MockitoSugar {
@@ -77,7 +78,6 @@ class CorrectionCountryControllerSpec extends SpecBase with MockitoSugar {
     "must redirect to the next page when valid data is submitted" in {
 
       val mockSessionRepository = mock[SessionRepository]
-
       val updatedAnswers = emptyUserAnswers.set(CorrectionCountryPage(period, index), country).get
 
       when(mockSessionRepository.set(updatedAnswers)) thenReturn Future.successful(true)
@@ -85,7 +85,7 @@ class CorrectionCountryControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[SessionRepository].toInstance(mockSessionRepository),
           )
           .build()
 
@@ -98,7 +98,11 @@ class CorrectionCountryControllerSpec extends SpecBase with MockitoSugar {
 
         status(result) mustEqual SEE_OTHER
 
-        redirectLocation(result).value mustEqual controllers.corrections.routes.CorrectionCountryController.onPageLoad(waypoints, index).url // Todo, will change when the next page is implemented
+        redirectLocation(result).value mustEqual
+          CorrectionCountryPage(
+            period,
+            index
+          ).navigate(waypoints, emptyUserAnswers, updatedAnswers).url
       }
     }
 

--- a/test/controllers/corrections/UndeclaredCountryCorrectionControllerSpec.scala
+++ b/test/controllers/corrections/UndeclaredCountryCorrectionControllerSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.corrections
+
+import base.SpecBase
+import forms.corrections.UndeclaredCountryCorrectionFormProvider
+import models.Country
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatestplus.mockito.MockitoSugar
+import pages.corrections.{CorrectionCountryPage, UndeclaredCountryCorrectionPage}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.corrections.UndeclaredCountryCorrectionView
+
+class UndeclaredCountryCorrectionControllerSpec extends SpecBase with MockitoSugar {
+  private val selectedCountry = arbitrary[Country].sample.value
+  private val formProvider = new UndeclaredCountryCorrectionFormProvider()
+  private val form = formProvider()
+  private val userAnswersWithCountryAndPeriod = emptyUserAnswers.set(CorrectionCountryPage(period, index), selectedCountry).success.value
+
+  private lazy val undeclaredCountryCorrectionRoute = UndeclaredCountryCorrectionPage(period, index).route(waypoints).url
+
+  "UndeclaredCountryCorrection Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCountryAndPeriod))
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, undeclaredCountryCorrectionRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[UndeclaredCountryCorrectionView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, waypoints, period, selectedCountry, index)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = userAnswersWithCountryAndPeriod.set(UndeclaredCountryCorrectionPage(period, index), true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers))
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, undeclaredCountryCorrectionRoute)
+
+        val view = application.injector.instanceOf[UndeclaredCountryCorrectionView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), waypoints, period, selectedCountry, index)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCountryAndPeriod))
+        .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, undeclaredCountryCorrectionRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+        val expectedAnswers = userAnswersWithCountryAndPeriod.set(UndeclaredCountryCorrectionPage(period, index), true).success.value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual UndeclaredCountryCorrectionPage(period, index).navigate(waypoints, userAnswersWithCountryAndPeriod, expectedAnswers).url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCountryAndPeriod))
+        .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, undeclaredCountryCorrectionRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[UndeclaredCountryCorrectionView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, waypoints, period, selectedCountry, index)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, undeclaredCountryCorrectionRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, undeclaredCountryCorrectionRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/corrections/VatAmountCorrectionCountryControllerSpec.scala
+++ b/test/controllers/corrections/VatAmountCorrectionCountryControllerSpec.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.corrections
+
+import base.SpecBase
+import forms.corrections.VatAmountCorrectionCountryFormProvider
+import models.Country
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.mockito.MockitoSugar.{times, verify}
+import org.mockito.{ArgumentMatchersSugar, Mockito}
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.mockito.MockitoSugar
+import pages.corrections.{CorrectionCountryPage, UndeclaredCountryCorrectionPage, VatAmountCorrectionCountryPage, VatPayableForCountryPage}
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.corrections.VatAmountCorrectionCountryView
+
+import scala.concurrent.Future
+
+class VatAmountCorrectionCountryControllerSpec extends SpecBase with MockitoSugar with BeforeAndAfterEach {
+
+  private val mockSessionRepository = mock[SessionRepository]
+
+  private val selectedCountry = arbitrary[Country].sample.value
+
+  private val formProvider = new VatAmountCorrectionCountryFormProvider()
+  private val form = formProvider(selectedCountry.name)
+  private val userAnswersWithCountryAndPeriod = emptyUserAnswers.set(CorrectionCountryPage(period, index), selectedCountry).flatMap(_.set(UndeclaredCountryCorrectionPage(period, index), true)).success.value
+
+  private val validAnswer = BigDecimal(10)
+
+  private lazy val countryVatCorrectionRoute =
+    VatAmountCorrectionCountryPage(period, index).route(waypoints).url
+
+  override def beforeEach(): Unit = {
+    Mockito.reset(mockSessionRepository)
+  }
+
+  "VatAmountCorrectionCountry Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCountryAndPeriod))
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, countryVatCorrectionRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[VatAmountCorrectionCountryView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(
+          form, waypoints, period, index, selectedCountry
+        )(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+      val userAnswers =
+        userAnswersWithCountryAndPeriod.set(VatAmountCorrectionCountryPage(period, index), validAnswer).success.value
+
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers))
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, countryVatCorrectionRoute)
+
+        val view = application.injector.instanceOf[VatAmountCorrectionCountryView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(
+          form.fill(validAnswer), waypoints, period, index, selectedCountry
+        )(request, messages(application)).toString
+      }
+    }
+
+    "must save the answer and redirect to the next page when valid data is submitted" in {
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(userAnswersWithCountryAndPeriod))
+          .overrides(bind[SessionRepository].toInstance(mockSessionRepository))
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, countryVatCorrectionRoute)
+            .withFormUrlEncodedBody(("value", validAnswer.toString))
+
+        val result = route(application, request).value
+        val expectedAnswers =
+          userAnswersWithCountryAndPeriod.set(VatAmountCorrectionCountryPage(period, index), validAnswer).success.value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual VatPayableForCountryPage(period, index).route(waypoints).url
+
+        verify(mockSessionRepository, times(1)).set(ArgumentMatchersSugar.eqTo(expectedAnswers))
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCountryAndPeriod))
+        .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, countryVatCorrectionRoute)
+            .withFormUrlEncodedBody(("value", "invalid value"))
+
+        val boundForm = form.bind(Map("value" -> "invalid value"))
+
+        val view = application.injector.instanceOf[VatAmountCorrectionCountryView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(
+          boundForm, waypoints, period, index, selectedCountry
+        )(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, countryVatCorrectionRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no correction period or country found in user answers" in {
+
+      val application = applicationBuilder(Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, countryVatCorrectionRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, countryVatCorrectionRoute)
+            .withFormUrlEncodedBody(("value", validAnswer.toString))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no correction period or country found in user answers" in {
+
+      val application = applicationBuilder(Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, countryVatCorrectionRoute)
+            .withFormUrlEncodedBody(("value", validAnswer.toString))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/corrections/VatPayableForCountryControllerSpec.scala
+++ b/test/controllers/corrections/VatPayableForCountryControllerSpec.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.corrections
+
+import base.SpecBase
+import forms.corrections.VatPayableForCountryFormProvider
+import models.{Country, Index}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.corrections.{CorrectionCountryPage, VatAmountCorrectionCountryPage, VatPayableForCountryPage}
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.corrections.VatPayableForCountryView
+
+import scala.concurrent.Future
+
+class VatPayableForCountryControllerSpec extends SpecBase with MockitoSugar {
+
+  private val formProvider = new VatPayableForCountryFormProvider()
+  private val form = formProvider(Country("DE", "Germany"), BigDecimal(1000))
+
+  private lazy val vatPayableForCountryRoute = controllers.corrections.routes.VatPayableForCountryController.onPageLoad(waypoints, Index(0)).url
+
+  "VatPayableForCountry Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val userAnswers = emptyUserAnswers
+        .set(CorrectionCountryPage(period, index), Country("DE", "Germany")).success.value
+        .set(VatAmountCorrectionCountryPage(period, index), BigDecimal(1000)).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers))
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, vatPayableForCountryRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[VatPayableForCountryView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, waypoints, Index(0), Country("DE", "Germany"), period, BigDecimal(1000))(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = emptyUserAnswers
+        .set(VatPayableForCountryPage(period, Index(0)), true).success.value
+        .set(CorrectionCountryPage(period, index), Country("DE", "Germany")).success.value
+        .set(VatAmountCorrectionCountryPage(period, index), BigDecimal(1000)).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers))
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, vatPayableForCountryRoute)
+
+        val view = application.injector.instanceOf[VatPayableForCountryView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(
+          form.fill(true),
+          waypoints,
+          Index(0),
+          Country("DE", "Germany"),
+          period,
+          BigDecimal(1000)
+        )(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val userAnswers = emptyUserAnswers
+        .set(CorrectionCountryPage(period, index), Country("DE", "Germany")).success.value
+        .set(VatAmountCorrectionCountryPage(period, index), BigDecimal(1000)).success.value
+
+      val application =
+        applicationBuilder(userAnswers = Some(userAnswers))
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, vatPayableForCountryRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+        val expectedAnswers = userAnswers.set(VatPayableForCountryPage(period, Index(0)), true).success.value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual VatPayableForCountryPage(period, Index(0)).navigate(waypoints, userAnswers, expectedAnswers).url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val userAnswers = emptyUserAnswers
+        .set(VatPayableForCountryPage(period, index), true).success.value
+        .set(CorrectionCountryPage(period, index), Country("DE", "Germany")).success.value
+        .set(VatAmountCorrectionCountryPage(period, index), BigDecimal(1000)).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers))
+        .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, vatPayableForCountryRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[VatPayableForCountryView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(
+          boundForm,
+          waypoints,
+          Index(0),
+          Country("DE", "Germany"),
+          period,
+          BigDecimal(1000)
+        )(
+          request, messages(application)
+        ).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, vatPayableForCountryRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no correction period or country found" in {
+
+      val application = applicationBuilder(Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, vatPayableForCountryRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, vatPayableForCountryRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no correction period or country found" in {
+
+      val application = applicationBuilder(Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, vatPayableForCountryRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/forms/corrections/CorrectionsCountryFormProviderSpec.scala
+++ b/test/forms/corrections/CorrectionsCountryFormProviderSpec.scala
@@ -16,7 +16,6 @@
 
 package forms.corrections
 
-import forms.CorrectionCountryFormProvider
 import forms.behaviours.StringFieldBehaviours
 import models.{Country, Index}
 import org.scalacheck.Arbitrary.arbitrary

--- a/test/forms/corrections/UndeclaredCountryCorrectionFormProviderSpec.scala
+++ b/test/forms/corrections/UndeclaredCountryCorrectionFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.corrections
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class UndeclaredCountryCorrectionFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "undeclaredCountryCorrection.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new UndeclaredCountryCorrectionFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/corrections/VatAmountCorrectionCountryFormProviderSpec.scala
+++ b/test/forms/corrections/VatAmountCorrectionCountryFormProviderSpec.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.corrections
+
+import config.Constants.{maxCurrencyAmount, minCurrencyAmount}
+import forms.behaviours.DecimalFieldBehaviours
+import org.scalacheck.Gen
+import play.api.data.FormError
+import utils.CurrencyFormatter
+
+import scala.math.BigDecimal.RoundingMode
+
+class VatAmountCorrectionCountryFormProviderSpec extends DecimalFieldBehaviours {
+
+  private val country = "Country"
+
+  val minimum = minCurrencyAmount
+  val maximum = maxCurrencyAmount
+
+  val form = new VatAmountCorrectionCountryFormProvider()(country)
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    val validDataGeneratorForPositive =
+      Gen.choose[BigDecimal](BigDecimal(0.01), maximum)
+        .map(_.setScale(2, RoundingMode.HALF_UP))
+        .map(_.toString)
+
+    val validDataGeneratorForNegative =
+      Gen.choose[BigDecimal](minimum, BigDecimal(-0.01))
+        .map(_.setScale(2, RoundingMode.HALF_UP))
+        .map(_.toString)
+
+    val validDataGeneratorForOutOfRangeNegative =
+      Gen.choose[BigDecimal](minimum - 1000, minimum - 0.01)
+        .map(_.setScale(2, RoundingMode.HALF_DOWN))
+        .map(_.toString)
+
+    "bind valid data positive" in {
+
+      forAll(validDataGeneratorForPositive -> "validDataItem") {
+        dataItem: String =>
+          val result = form.bind(Map(fieldName -> dataItem)).apply(fieldName)
+          result.value.value mustBe dataItem
+          result.errors mustBe empty
+      }
+    }
+
+    "bind valid data negative" in {
+      forAll(validDataGeneratorForNegative -> "validDataItem") {
+        dataItem: String =>
+          val result = form.bind(Map(fieldName -> dataItem)).apply(fieldName)
+          result.value.value mustBe dataItem
+          result.errors mustBe empty
+      }
+    }
+
+    behave like decimalField(
+      form,
+      fieldName,
+      nonNumericError  = FormError(fieldName, "vatAmountCorrectionCountry.error.nonNumeric", Seq(country)),
+      invalidNumericError = FormError(fieldName, "vatAmountCorrectionCountry.error.wholeNumber", Seq(country))
+    )
+
+    behave like decimalFieldWithRange(
+      form,
+      fieldName,
+      minimum       = minimum,
+      maximum       = maximum,
+      expectedError = FormError(fieldName, "vatAmountCorrectionCountry.error.outOfRange.undeclared", Seq(minimum, maximum))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, "vatAmountCorrectionCountry.error.required", Seq(country))
+    )
+
+    "show correct error" in {
+      val form = new VatAmountCorrectionCountryFormProvider()(country)
+
+      val result = form.bind(Map(fieldName -> (maximum + 0.01).toString)).apply(fieldName)
+      result.errors mustEqual Seq(FormError(fieldName, "vatAmountCorrectionCountry.error.outOfRange.undeclared", Seq(minimum, maximum)))
+    }
+
+
+    "show correct error when country undeclared" in {
+      val form = new VatAmountCorrectionCountryFormProvider()(country)
+
+      val result = form.bind(Map(fieldName -> (maximum + 0.01).toString)).apply(fieldName)
+      result.errors mustEqual Seq(FormError(fieldName, "vatAmountCorrectionCountry.error.outOfRange.undeclared", Seq(minimum, maximum)))
+    }
+
+    "fail when value is below minimum allowed correction" in {
+
+      val form = new VatAmountCorrectionCountryFormProvider()(country)
+
+      forAll(validDataGeneratorForOutOfRangeNegative -> "validDataItem") {
+        dataItem: String =>
+          val result = form.bind(Map(fieldName -> dataItem)).apply(fieldName)
+          result.value.value mustBe dataItem
+          result.errors mustBe List(FormError(fieldName, "vatAmountCorrectionCountry.error.outOfRange.undeclared", Seq(minimum, maximum)))
+      }
+    }
+  }
+}

--- a/test/forms/corrections/VatPayableForCountryFormProviderSpec.scala
+++ b/test/forms/corrections/VatPayableForCountryFormProviderSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.corrections
+
+import forms.behaviours.BooleanFieldBehaviours
+import models.Country
+import play.api.data.FormError
+
+class VatPayableForCountryFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "vatPayableForCountry.error.required"
+  val invalidKey = "error.boolean"
+  val form = new VatPayableForCountryFormProvider()(Country("DE", "Germany"), BigDecimal(10))
+  val errorArgs = Seq("Germany", "&pound;10")
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey, errorArgs)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey, errorArgs)
+    )
+  }
+}


### PR DESCRIPTION
Once the dependant tickets are merged, additional work highlighted below must be added:
A.  cc.authAndRequireData().async {
      // ToDo: Downstream not ready to check Correction Eligibility yet.
      // ToDo: Enhance the auth when ready
   
B.     val period = request.userAnswers.period
        //Todo: Change this to correction period when ready